### PR TITLE
fix compilation errors

### DIFF
--- a/intermediate.go
+++ b/intermediate.go
@@ -16,7 +16,7 @@ func intermediateSet(db *badger.DB, key, value []byte) error {
 		return err
 	}
 
-	err = tx.Commit()
+	err = tx.Commit(nil)
 	if err == badger.ErrConflict {
 		return ErrCounterChanged
 	}
@@ -39,7 +39,7 @@ func intermediateCAS(db *badger.DB, key, value []byte, counter uint64) error {
 		return err
 	}
 
-	err = tx.Commit()
+	err = tx.Commit(nil)
 	if err == badger.ErrConflict {
 		return ErrCounterChanged
 	}
@@ -54,7 +54,7 @@ func intermediateDelete(db *badger.DB, key []byte) error {
 		return err
 	}
 
-	err = tx.Commit()
+	err = tx.Commit(nil)
 	if err == badger.ErrConflict {
 		return ErrCounterChanged
 	}
@@ -77,7 +77,7 @@ func intermediateCAD(db *badger.DB, key []byte, counter uint64) error {
 		return err
 	}
 
-	err = tx.Commit()
+	err = tx.Commit(nil)
 	if err == badger.ErrConflict {
 		return ErrCounterChanged
 	}


### PR DESCRIPTION
When tried to use cete v0.2 I have got the following errors. So this patch fixes this issue.
```
vendor/github.com/1lann/cete/intermediate.go:19:17: not enough arguments in call to tx.Commit
	have ()
	want (func(error))
vendor/github.com/1lann/cete/intermediate.go:42:17: not enough arguments in call to tx.Commit
	have ()
	want (func(error))
vendor/github.com/1lann/cete/intermediate.go:57:17: not enough arguments in call to tx.Commit
	have ()
	want (func(error))
vendor/github.com/1lann/cete/intermediate.go:80:17: not enough arguments in call to tx.Commit
	have ()
	want (func(error))
```