### PR TITLE
Locked dependency versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+vendor/
+.idea/

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,49 @@
+hash: b205dbda75892df61b04a0d02485c7ca94eae9787629fd02ea096bde6c0757ca
+updated: 2019-04-01T17:47:08.374213+11:00
+imports:
+- name: github.com/1lann/msgpack
+  version: fdd7618e197cf7a11481cda1810608f349fbb88c
+  subpackages:
+  - codes
+- name: github.com/AndreasBriese/bbloom
+  version: 343706a395b76e5ca5c7dca46a5d937b48febc74
+- name: github.com/dgraph-io/badger
+  version: deee8c7ae70bab412e4f10cfa068e0be61a8d0eb
+  subpackages:
+  - options
+  - pb
+  - skl
+  - table
+  - "y"
+- name: github.com/dgryski/go-farm
+  version: 2de33835d10275975374b37b2dcfd22c9020a1f5
+- name: github.com/dustin/go-humanize
+  version: 9f541cc9db5d55bce703bd99987c9d5cb8eea45e
+- name: github.com/golang/protobuf
+  version: aa810b61a9c79d51363740d207bb46cf8e620ed5
+  subpackages:
+  - proto
+- name: github.com/pkg/errors
+  version: ba968bfe8b2f7e042a574c888954fccecfa385b4
+- name: golang.org/x/net
+  version: c44066c5c816ec500d459a2a324a753f78531ae0
+  subpackages:
+  - context
+  - internal/timeseries
+  - trace
+- name: golang.org/x/sys
+  version: 95b1ffbd15a57cc5abb3f04402b9e8ec0016a52c
+  subpackages:
+  - unix
+- name: google.golang.org/appengine
+  version: 54a98f90d1c46b7731eb8fb305d2a321c30ef610
+  subpackages:
+  - datastore
+  - internal
+  - internal/app_identity
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/modules
+  - internal/remote_api
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,6 @@
+package: github.com/1lann/cete
+import:
+- package: github.com/1lann/msgpack
+  version: fdd7618
+- package: github.com/dgraph-io/badger
+  version: v2.0.0-rc.2+incompatible


### PR DESCRIPTION
Compilation error fixed, was getting many of these:
```
vendor/github.com/1lann/cete/intermediate.go:19:17: not enough arguments in call to tx.Commit
    have ()
    want (func(error))
```

Also msgpack was giving issues, so locked the version in place with [`glide`](https://github.com/Masterminds/glide).